### PR TITLE
fix: PUT requests was mistakenly labeled as POST

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export const logger = () => new Elysia({
 
         case 'PUT':
             // Handle PUT request
-            logStr.push(pc.blue("POST"))
+            logStr.push(pc.blue("PUT"))
 
             break;
 


### PR DESCRIPTION
Previously, the logger for PUT requests was mistakenly labeled as POST